### PR TITLE
only show the buttons to start/stop table sessions to admins

### DIFF
--- a/app/components/TableCard.test.tsx
+++ b/app/components/TableCard.test.tsx
@@ -1,42 +1,93 @@
 import { render, screen } from "@testing-library/react"
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 import { TableCard } from "#app/components/TableCard"
-describe("TableCard", () => {
-    it("renders table name and availability", () => {
-        render(<TableCard table={{
-            id: 1,
-            name: "Table 1",
-            inUse: false,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-            sessions: []
-        }}   />)
+import { useOptionalUser, userHasRole } from "#app/utils/user"
 
-        expect(screen.getByText("Table 1")).toBeInTheDocument()
-        expect(screen.getByText("Available")).toBeInTheDocument()
-        expect(screen.getByText("No session in progress")).toBeInTheDocument()
+vi.mock("#app/utils/user")
+
+const mockTable = {
+    id: 1,
+    name: "Table 1",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    sessions: [] as any[],
+}
+
+const mockTableWithSession = {
+    ...mockTable,
+    inUse: true,
+    sessions: [{
+        id: 1,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        tableId: 1,
+        startedAt: new Date(),
+        endedAt: null,
+        createdById: null,
+        formattedStartedAt: "12:00",
+    }]
+}
+
+const mockAdminUser = {
+    id: "1",
+    name: "Admin User",
+    username: "admin",
+    image: null,
+    roles: [{ 
+        name: "admin",
+        permissions: []
+    }],
+}
+
+const mockRegularUser = {
+    id: "2",
+    name: "Regular User",
+    username: "user",
+    image: null,
+    roles: [{ 
+        name: "user",
+        permissions: []
+    }],
+}
+
+describe("TableCard", () => {
+    describe("when logged in as admin", () => {
+        beforeEach(() => {
+            vi.mocked(useOptionalUser).mockReturnValue(mockAdminUser)
+            vi.mocked(userHasRole).mockReturnValue(true)
+        })
+
+        it("renders table and availability when not in use", () => {
+            render(<TableCard table={{ ...mockTable, inUse: false }} />)
+
+            expect(screen.getByText("Table 1")).toBeInTheDocument()
+            expect(screen.getByText("Available")).toBeInTheDocument()
+            expect(screen.getByText("No session in progress")).toBeInTheDocument()
+            expect(screen.queryByText("Mark In Use")).toBeInTheDocument()
+        })
+
+        it("renders in use when the table is in use", () => {
+            render(<TableCard table={mockTableWithSession} />)
+            
+            expect(screen.getByText("In Use")).toBeInTheDocument()
+            expect(screen.getByText(/Started at:.*12:00/i)).toBeInTheDocument()
+            expect(screen.getByText(/In Use for:.*m/i)).toBeInTheDocument()
+            expect(screen.getByText("Mark Available")).toBeInTheDocument()
+        })
     })
-    it("renders in use when the table is in use", () => {
-        render(<TableCard table={{
-            id: 1,
-            name: "Table 1",
-            inUse: true,
-            createdAt: new Date(),
-            updatedAt: new Date(),
-            sessions: [
-                {
-                    id: 1,
-                    createdAt: new Date(),
-                    updatedAt: new Date(),
-                    tableId: 1,
-                    startedAt: new Date(),
-                    endedAt: null,
-                    createdById: null,
-                    formattedStartedAt: "12:00",
-                }
-            ]
-        }} />)
-        expect(screen.getByText("In Use")).toBeInTheDocument()
-        expect(screen.getByText("Mark Available")).toBeInTheDocument()
+
+    describe("session buttons are not visible when logged in as non-admin", () => {
+        beforeEach(() => {
+            vi.mocked(useOptionalUser).mockReturnValue(mockRegularUser)
+            vi.mocked(userHasRole).mockReturnValue(false)
+        })
+
+        it("does not render admin buttons", () => {
+            render(<TableCard table={{ ...mockTable, inUse: false }} />)
+
+            expect(screen.queryByText("Mark In Use")).not.toBeInTheDocument()
+            expect(screen.queryByText("Mark Available")).not.toBeInTheDocument()
+        })
     })
 })
+

--- a/app/components/TableCard.tsx
+++ b/app/components/TableCard.tsx
@@ -2,6 +2,7 @@ import { getDurationSince } from "#app/utils/time.ts"
 import { Button } from "./ui/button"
 import { useEffect, useState } from "react"
 import type { Table, TableSession } from "@prisma/client"
+import { useOptionalUser, userHasRole } from "#app/utils/user"
 type Props = {
     table: Table & {
         sessions: (TableSession & { formattedStartedAt: string })[]
@@ -9,6 +10,7 @@ type Props = {
 }
 
 export function TableCard({ table }: Props) {
+    const user = useOptionalUser()
     const activeSession = table.sessions[0]
     const [ duration, setDuration ] = useState<string | null>(null)
 
@@ -62,25 +64,27 @@ export function TableCard({ table }: Props) {
                   </span>
                 </div>
   
-                {table.inUse ? (
-                  // End session
-                  <form method="POST">
-                    <input type="hidden" name="tableId" value={table.id} />
-                    <input type="hidden" name="endSession" value="true" />
-                    <Button type="submit" variant="destructive">
-                      Mark Available
-                    </Button>
-                  </form>
-                ) : (
-                  // Start session
-                  <form method="POST">
-                    <input type="hidden" name="tableId" value={table.id} />
-                    <input type="hidden" name="currentStatus" value={table.inUse.toString()} />
-                    <Button type="submit" variant="default">
-                      Mark In Use
-                    </Button>
-                  </form>
-                )}
+                {user && userHasRole(user, "admin") ? (
+                  table.inUse ? (
+                    // End session
+                    <form method="POST">
+                      <input type="hidden" name="tableId" value={table.id} />
+                      <input type="hidden" name="endSession" value="true" />
+                      <Button type="submit" variant="destructive">
+                        Mark Available
+                      </Button>
+                    </form>
+                  ) : (
+                    // Start session
+                    <form method="POST">
+                      <input type="hidden" name="tableId" value={table.id} />
+                      <input type="hidden" name="currentStatus" value={table.inUse.toString()} />
+                      <Button type="submit" variant="default">
+                        Mark In Use
+                      </Button>
+                    </form>
+                  )
+                ) : null}
               </div>
             </div>
           )

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -116,7 +116,7 @@ async function seed() {
 	
 	await prisma.table.createMany({
 		data: [
-			{ name: 'Table 1', inUse: true },
+			{ name: 'Table 1', inUse: false },
 			{ name: 'Table 2', inUse: false },
 			{ name: 'Table 3', inUse: false },
 			{ name: 'Table 4', inUse: false },


### PR DESCRIPTION
<!-- Summary: Put your summary here -->

## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated

## Screenshots

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
